### PR TITLE
[CATIONA-114] - Ion chart legends get overlapped in case of smaller width

### DIFF
--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -254,46 +254,6 @@ function drawOne(gd, opts) {
                     ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
                 } else {
                     ly = fullLayout.height * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
-                    hideLegendInPopup = true;
-                }
-
-                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
-
-                if (legendVerticalPositionOutsidePlot) {
-                    const tickLabels = fullLayout._cartesianlayer.selectAll('g[class$="tick"]')[0];
-                    if (tickLabels.length) {
-                        if (legendVerticalPositionOutsidePlot === 'bottom') {
-                            let bottomMostTick = tickLabels[0];
-                            let bottomMostTickBottomPosition = bottomMostTick.getBoundingClientRect().bottom;
-                            for (let i = 1; i < tickLabels.length; i++) {
-                                const tickBottomPosition = tickLabels[i].getBoundingClientRect().bottom;
-                                if (bottomMostTickBottomPosition < tickBottomPosition) {
-                                    bottomMostTick = tickLabels[i];
-                                    bottomMostTickBottomPosition = tickBottomPosition;
-                                }
-                            }
-                            if (bottomMostTickBottomPosition > ly + legendObj._effHeight) {
-                                legendObj.y -= bottomMostTick.getBoundingClientRect().height / fullLayout.height;
-                                ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
-                                ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
-                            }
-                        } else {
-                            let topMostTick = tickLabels[0];
-                            let topMostTickTopPosition = topMostTick.getBoundingClientRect().top;
-                            for (let i = 1; i < tickLabels.length; i++) {
-                                const tickTopPosition = tickLabels[i].getBoundingClientRect().top;
-                                if (topMostTickTopPosition > tickTopPosition) {
-                                    topMostTick = tickLabels[i];
-                                    topMostTickTopPosition = tickTopPosition;
-                                }
-                            }
-                            if (topMostTickTopPosition < ly) {
-                                legendObj.y += topMostTick.getBoundingClientRect().height / fullLayout.height;
-                                ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
-                                ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
-                            }
-                        }
-                    }
                 }
 
                 var expMargin = expandMargin(gd, legendId, lx, ly);
@@ -316,13 +276,41 @@ function drawOne(gd, opts) {
                     }
                     if(ly !== ly0) {
                         Lib.log('Constrain ' + legendId + '.y to make legend fit inside graph');
-                        hideLegendInPopup = true;
                     }
                 }
 
                 // Set size and position of all the elements that make up a legend:
                 // legend, background and border, scroll box and scroll bar as well as title
                 Drawing.setTranslate(legend, lx, ly);
+
+                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
+                const cartesianNode = fullLayout._cartesianlayer.node();
+                const cartesianNodeBoundRect = cartesianNode.getBoundingClientRect();
+                const legendNodeBoundRect = legend.node().getBoundingClientRect();
+                const legendPaddingDelta = 2 * (bw + constants.itemGap);
+                if (legendVerticalPositionOutsidePlot) {
+                    const ly0 = ly;
+                    if (legendVerticalPositionOutsidePlot === 'bottom') {
+                        if (cartesianNodeBoundRect.bottom > legendNodeBoundRect.top) {
+                            const delta = cartesianNodeBoundRect.bottom - legendNodeBoundRect.top + legendPaddingDelta;
+                            legendObj.y -= delta / fullLayout.height;
+                            ly += delta;
+                        }
+                    } else {
+                        if (cartesianNodeBoundRect.top < legendNodeBoundRect.bottom) {
+                            const delta = legendNodeBoundRect.bottom - cartesianNodeBoundRect.top + legendPaddingDelta;
+                            legendObj.y += delta / fullLayout.height;
+                            ly -= delta;
+                        }
+                    }
+
+                    if (ly !== ly0) {
+                        const expMargin = expandMargin(gd, legendId, lx, ly);
+                        if (expMargin) return;
+                        ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
+                        Drawing.setTranslate(legend, lx, ly);
+                    }
+                }
             }
 
             // Set size and position of all the elements that make up a legend:

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -285,36 +285,27 @@ function drawOne(gd, opts) {
                 // legend, background and border, scroll box and scroll bar as well as title
                 Drawing.setTranslate(legend, lx, ly);
 
-                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
+                const legendVerticalPositionOutsideBottom = legendObj.y < 0;
                 const cartesianNode = fullLayout._cartesianlayer.node();
                 const cartesianNodeBoundRect = cartesianNode.getBoundingClientRect();
                 const hasTickLabels = fullLayout._cartesianlayer.selectAll('g[class$="tick"]').size() > 0;
                 const legendNodeBoundRect = legend.node().getBoundingClientRect();
                 const legendPaddingDelta = 2 * (bw + constants.itemGap);
-                if (legendVerticalPositionOutsidePlot) {
+                if (legendVerticalPositionOutsideBottom) {
                     if (legendObj._effHeight / fullLayout.height >= 0.5) {
                         hideLegendInPopup = true;
                     } else if (hasTickLabels) {
                         const intialLy = ly;
-                        if (legendVerticalPositionOutsidePlot === 'bottom') {
-                            if (cartesianNodeBoundRect.bottom > legendNodeBoundRect.top) {
-                                const delta = cartesianNodeBoundRect.bottom - legendNodeBoundRect.top + legendPaddingDelta;
-                                legendObj.y -= (delta / fullLayout.height);
-                                ly += delta;
-                            }
-                        } else {
-                            if (cartesianNodeBoundRect.top < legendNodeBoundRect.bottom) {
-                                const delta = legendNodeBoundRect.bottom - cartesianNodeBoundRect.top + legendPaddingDelta;
-                                legendObj.y += (delta / fullLayout.height);
-                                ly -= delta;
-                            }
+                        if (cartesianNodeBoundRect.bottom > legendNodeBoundRect.top) {
+                            const delta = cartesianNodeBoundRect.bottom - legendNodeBoundRect.top + legendPaddingDelta;
+                            legendObj.y -= (delta / fullLayout.height);
+                            ly += delta;
                         }
 
                         if (ly !== intialLy) {
                             const expMargin = expandMargin(gd, legendId, lx, ly);
                             if (expMargin) return;
                             ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
-                            Drawing.setTranslate(legend, lx, ly);
                         }
                     }
                 }

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -254,6 +254,7 @@ function drawOne(gd, opts) {
                     ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
                 } else {
                     ly = fullLayout.height * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
+                    hideLegendInPopup = true;
                 }
 
                 var expMargin = expandMargin(gd, legendId, lx, ly);
@@ -276,6 +277,7 @@ function drawOne(gd, opts) {
                     }
                     if(ly !== ly0) {
                         Lib.log('Constrain ' + legendId + '.y to make legend fit inside graph');
+                        hideLegendInPopup = true;
                     }
                 }
 
@@ -286,29 +288,34 @@ function drawOne(gd, opts) {
                 const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
                 const cartesianNode = fullLayout._cartesianlayer.node();
                 const cartesianNodeBoundRect = cartesianNode.getBoundingClientRect();
+                const hasTickLabels = fullLayout._cartesianlayer.selectAll('g[class$="tick"]').size() > 0;
                 const legendNodeBoundRect = legend.node().getBoundingClientRect();
                 const legendPaddingDelta = 2 * (bw + constants.itemGap);
                 if (legendVerticalPositionOutsidePlot) {
-                    const ly0 = ly;
-                    if (legendVerticalPositionOutsidePlot === 'bottom') {
-                        if (cartesianNodeBoundRect.bottom > legendNodeBoundRect.top) {
-                            const delta = cartesianNodeBoundRect.bottom - legendNodeBoundRect.top + legendPaddingDelta;
-                            legendObj.y -= delta / fullLayout.height;
-                            ly += delta;
+                    if (legendObj._effHeight / fullLayout.height >= 0.5) {
+                        hideLegendInPopup = true;
+                    } else if (hasTickLabels) {
+                        const intialLy = ly;
+                        if (legendVerticalPositionOutsidePlot === 'bottom') {
+                            if (cartesianNodeBoundRect.bottom > legendNodeBoundRect.top) {
+                                const delta = cartesianNodeBoundRect.bottom - legendNodeBoundRect.top + legendPaddingDelta;
+                                legendObj.y -= (delta / fullLayout.height);
+                                ly += delta;
+                            }
+                        } else {
+                            if (cartesianNodeBoundRect.top < legendNodeBoundRect.bottom) {
+                                const delta = legendNodeBoundRect.bottom - cartesianNodeBoundRect.top + legendPaddingDelta;
+                                legendObj.y += (delta / fullLayout.height);
+                                ly -= delta;
+                            }
                         }
-                    } else {
-                        if (cartesianNodeBoundRect.top < legendNodeBoundRect.bottom) {
-                            const delta = legendNodeBoundRect.bottom - cartesianNodeBoundRect.top + legendPaddingDelta;
-                            legendObj.y += delta / fullLayout.height;
-                            ly -= delta;
-                        }
-                    }
 
-                    if (ly !== ly0) {
-                        const expMargin = expandMargin(gd, legendId, lx, ly);
-                        if (expMargin) return;
-                        ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
-                        Drawing.setTranslate(legend, lx, ly);
+                        if (ly !== intialLy) {
+                            const expMargin = expandMargin(gd, legendId, lx, ly);
+                            if (expMargin) return;
+                            ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
+                            Drawing.setTranslate(legend, lx, ly);
+                        }
                     }
                 }
             }

--- a/src/components/legend/draw.js
+++ b/src/components/legend/draw.js
@@ -257,6 +257,45 @@ function drawOne(gd, opts) {
                     hideLegendInPopup = true;
                 }
 
+                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
+
+                if (legendVerticalPositionOutsidePlot) {
+                    const tickLabels = fullLayout._cartesianlayer.selectAll('g[class$="tick"]')[0];
+                    if (tickLabels.length) {
+                        if (legendVerticalPositionOutsidePlot === 'bottom') {
+                            let bottomMostTick = tickLabels[0];
+                            let bottomMostTickBottomPosition = bottomMostTick.getBoundingClientRect().bottom;
+                            for (let i = 1; i < tickLabels.length; i++) {
+                                const tickBottomPosition = tickLabels[i].getBoundingClientRect().bottom;
+                                if (bottomMostTickBottomPosition < tickBottomPosition) {
+                                    bottomMostTick = tickLabels[i];
+                                    bottomMostTickBottomPosition = tickBottomPosition;
+                                }
+                            }
+                            if (bottomMostTickBottomPosition > ly + legendObj._effHeight) {
+                                legendObj.y -= bottomMostTick.getBoundingClientRect().height / fullLayout.height;
+                                ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
+                                ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
+                            }
+                        } else {
+                            let topMostTick = tickLabels[0];
+                            let topMostTickTopPosition = topMostTick.getBoundingClientRect().top;
+                            for (let i = 1; i < tickLabels.length; i++) {
+                                const tickTopPosition = tickLabels[i].getBoundingClientRect().top;
+                                if (topMostTickTopPosition > tickTopPosition) {
+                                    topMostTick = tickLabels[i];
+                                    topMostTickTopPosition = tickTopPosition;
+                                }
+                            }
+                            if (topMostTickTopPosition < ly) {
+                                legendObj.y += topMostTick.getBoundingClientRect().height / fullLayout.height;
+                                ly = gs.t + gs.h * (1 - legendObj.y) - FROM_TL[getYanchor(legendObj)] * legendObj._effHeight;
+                                ly = Lib.constrain(ly, 0, fullLayout.height - legendObj._effHeight);
+                            }
+                        }
+                    }
+                }
+
                 var expMargin = expandMargin(gd, legendId, lx, ly);
 
                 // IF expandMargin return a Promise (which is truthy),

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1937,6 +1937,10 @@ plots.autoMargin = function(gd, id, o) {
     );
 
     var maxSpaceW = Math.max(0, width - minFinalWidth);
+    if (fullLayout.legend && fullLayout.legend.maxwidth) {
+        maxSpaceW = Math.min(maxSpaceW, ((width * fullLayout.legend.maxwidth) / 100));
+    }
+    
     var maxSpaceH = Math.max(0, height - minFinalHeight);
 
     var pushMargin = fullLayout._pushmargin;
@@ -2121,6 +2125,9 @@ plots.doAutoMargin = function(gd) {
     );
 
     var maxSpaceW = Math.max(0, width - minFinalWidth);
+    if (fullLayout.legend && fullLayout.legend.maxwidth) {
+        maxSpaceW = Math.min(maxSpaceW, ((width * fullLayout.legend.maxwidth) / 100));
+    }
     var maxSpaceH = Math.max(0, height - minFinalHeight);
 
     if(maxSpaceW) {

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1941,6 +1941,9 @@ plots.autoMargin = function(gd, id, o) {
     const legendObj = fullLayout.legend;
     if (legendObj && legendObj.maxwidth) {
         maxSpaceW = Math.min(maxSpaceW, ((width * legendObj.maxwidth) / 100));
+        if (fullLayout._has('pie')) {
+            maxSpaceW = Math.max(maxSpaceW, width - height);
+        }
     }
     
     var maxSpaceH = Math.max(0, height - minFinalHeight);
@@ -2146,6 +2149,9 @@ plots.doAutoMargin = function(gd) {
     var maxSpaceW = Math.max(0, width - minFinalWidth);
     if (fullLayout.legend && fullLayout.legend.maxwidth) {
         maxSpaceW = Math.min(maxSpaceW, ((width * fullLayout.legend.maxwidth) / 100));
+        if (fullLayout._has('pie')) {
+            maxSpaceW = Math.max(maxSpaceW, width - height);
+        }
     }
     var maxSpaceH = Math.max(0, height - minFinalHeight);
 

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1964,18 +1964,18 @@ plots.autoMargin = function(gd, id, o) {
             }
 
             if (legendObj) {
-                // drop horizontal margin for the case for which legends are hidden
-                const legendHorizontalPositionOutsidePlot = legendObj.x > 1 ? 'right': legendObj.x < 0 ? 'left': null;
-
+                const legendHorizontalPositionOutsidePlot = legendObj.x > 1 || legendObj.x < 0;
+                
                 // this calculation needs to be refined to fully support dropping of horizontal margin.
                 if (legendHorizontalPositionOutsidePlot && ((o.l + o.r) >= (width * ((legendObj.maxwidth / 100) || 0.5)))) {
+                    // drop horizontal margin for the case for which legends are hidden
                     o.l = o.r = 0;
                 }
 
-                // drop vertical margin for the case for which legends are hidden
-                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
-
+                const legendVerticalPositionOutsidePlot = legendObj.y > 1 || legendObj.y < 0;
+                
                 if (legendVerticalPositionOutsidePlot && ((o.t + o.b) >= (height * 0.5))) {
+                    // drop vertical margin for the case for which legends are hidden
                     o.t = o.b = 0;
                 } 
             }

--- a/src/plots/plots.js
+++ b/src/plots/plots.js
@@ -1937,8 +1937,10 @@ plots.autoMargin = function(gd, id, o) {
     );
 
     var maxSpaceW = Math.max(0, width - minFinalWidth);
-    if (fullLayout.legend && fullLayout.legend.maxwidth) {
-        maxSpaceW = Math.min(maxSpaceW, ((width * fullLayout.legend.maxwidth) / 100));
+
+    const legendObj = fullLayout.legend;
+    if (legendObj && legendObj.maxwidth) {
+        maxSpaceW = Math.min(maxSpaceW, ((width * legendObj.maxwidth) / 100));
     }
     
     var maxSpaceH = Math.max(0, height - minFinalHeight);
@@ -1956,6 +1958,23 @@ plots.autoMargin = function(gd, id, o) {
                 // if no explicit pad is given, use 12px unless there's a
                 // specified margin that's smaller than that
                 pad = Math.min(0, margin.l, margin.r, margin.t, margin.b);
+            }
+
+            if (legendObj) {
+                // drop horizontal margin for the case for which legends are hidden
+                const legendHorizontalPositionOutsidePlot = legendObj.x > 1 ? 'right': legendObj.x < 0 ? 'left': null;
+
+                // this calculation needs to be refined to fully support dropping of horizontal margin.
+                if (legendHorizontalPositionOutsidePlot && ((o.l + o.r) >= (width * ((legendObj.maxwidth / 100) || 0.5)))) {
+                    o.l = o.r = 0;
+                }
+
+                // drop vertical margin for the case for which legends are hidden
+                const legendVerticalPositionOutsidePlot = legendObj.y > 1 ? 'top': legendObj.y < 0 ? 'bottom': null;
+
+                if (legendVerticalPositionOutsidePlot && ((o.t + o.b) >= (height * 0.5))) {
+                    o.t = o.b = 0;
+                } 
             }
 
             // if the item is too big, just give it enough automargin to


### PR DESCRIPTION
- fixed legend overlap issue in case of bigger tick labels.